### PR TITLE
Sean flicking mechanics 3

### DIFF
--- a/Pine/Assets/Scenes/MechanicsTestingScene_2.unity
+++ b/Pine/Assets/Scenes/MechanicsTestingScene_2.unity
@@ -1,0 +1,1149 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.6666667, g: 0.89411765, b: 1, a: 1}
+  m_AmbientEquatorColor: {r: 0, g: 0.29359746, b: 1.4679873, a: 1}
+  m_AmbientGroundColor: {r: 0.046608247, g: 0.09321643, b: 0.41099998, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 1
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 2100000, guid: c865b45a18067e549ab5c211b90fcf72, type: 2}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 0
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &57912693
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 344483460603484996, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 326632911}
+    - target: {fileID: 344483460603484996, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: DisplayMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 1852470287262542051, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 326632911}
+    - target: {fileID: 1852470287262542051, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: HideTutorial
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858612921013262, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 326632911}
+    - target: {fileID: 8609858612921013262, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: DisplayCredits
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613582857813, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 326632911}
+    - target: {fileID: 8609858613582857813, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: MoveCameraToStart
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021273, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_Name
+      value: Canvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609858613820021277, guid: 3f5269bfa030443a1811a24a7b92a110,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3f5269bfa030443a1811a24a7b92a110, type: 3}
+--- !u!224 &57912694 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6638923325810301350, guid: 3f5269bfa030443a1811a24a7b92a110,
+    type: 3}
+  m_PrefabInstance: {fileID: 57912693}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &57912695 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4192376591804573308, guid: 3f5269bfa030443a1811a24a7b92a110,
+    type: 3}
+  m_PrefabInstance: {fileID: 57912693}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &326632911 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1193910893100899836, guid: 9f392e1835f784044b1660dbbdd32911,
+    type: 3}
+  m_PrefabInstance: {fileID: 2099263140}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 38aa4164903a24725924d1e992039fb9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &607123492 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8609858613843055577, guid: 3f5269bfa030443a1811a24a7b92a110,
+    type: 3}
+  m_PrefabInstance: {fileID: 57912693}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &763756827
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 982565553}
+    m_Modifications:
+    - target: {fileID: 718717205129435584, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_Name
+      value: pinecone_01 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.36
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.18418694
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0942638a1c84d34e98877d7432bccec, type: 3}
+--- !u!4 &763756828 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+    type: 3}
+  m_PrefabInstance: {fileID: 763756827}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &859189964
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1797224797070821678, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_Name
+      value: CameraBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.62
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -35.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797070821679, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797694557048, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -88.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797694557048, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797694557048, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -58.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797694557049, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: movementType
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797694557049, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: movementDelay
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1797224797694557049, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+        type: 3}
+      propertyPath: initialObjectToFocusOn
+      value: 
+      objectReference: {fileID: 1652057912}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c, type: 3}
+--- !u!1001 &869321633
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7993336336032646260, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: treeObject
+      value: 
+      objectReference: {fileID: 3235536750669014927, guid: 8a3a313b9abba464dab8ad40d26201a2,
+        type: 3}
+    - target: {fileID: 7993336336032646260, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: objectToFlick
+      value: 
+      objectReference: {fileID: 1652057912}
+    - target: {fileID: 7993336336032646260, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: flicksUntilTreeGrowth
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646261, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_Name
+      value: Character
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.580002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7993336336032646263, guid: 8057eab9c83b5f9458aa2bfb35029dce,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8057eab9c83b5f9458aa2bfb35029dce, type: 3}
+--- !u!1001 &977328026
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 982565553}
+    m_Modifications:
+    - target: {fileID: 718717205129435584, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_Name
+      value: pinecone_01 (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.305904
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.6358128
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.1876564
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.983865
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.17891257
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 20.613
+      objectReference: {fileID: 0}
+    - target: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0942638a1c84d34e98877d7432bccec, type: 3}
+--- !u!4 &977328027 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7725289918457029940, guid: a0942638a1c84d34e98877d7432bccec,
+    type: 3}
+  m_PrefabInstance: {fileID: 977328026}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &982565552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 982565553}
+  m_Layer: 0
+  m_Name: CharacterControl
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &982565553
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982565552}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.2228413, y: 0.18418694, z: -10.761026}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 763756828}
+  - {fileID: 977328027}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!224 &1220485264 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8609858613585605520, guid: 3f5269bfa030443a1811a24a7b92a110,
+    type: 3}
+  m_PrefabInstance: {fileID: 57912693}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1417593126 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8609858613677882131, guid: 3f5269bfa030443a1811a24a7b92a110,
+    type: 3}
+  m_PrefabInstance: {fileID: 57912693}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1510097975
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1510097978}
+  - component: {fileID: 1510097977}
+  - component: {fileID: 1510097976}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1510097976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1510097975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1510097977
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1510097975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1510097978
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1510097975}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1652057911
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -20.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.09
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -58.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375353868752613787, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8204122781589130607, guid: 95255d0ba9fea6247b884a11e1ac732b,
+        type: 3}
+      propertyPath: m_Name
+      value: pinecone_physics_audio
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 95255d0ba9fea6247b884a11e1ac732b, type: 3}
+--- !u!1 &1652057912 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8204122781589130607, guid: 95255d0ba9fea6247b884a11e1ac732b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1652057911}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1788336988 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1797224797694557049, guid: 621eb59e7a9735f47b7bf3c34b6dbe6c,
+    type: 3}
+  m_PrefabInstance: {fileID: 859189964}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d63d0856c0ff3a4584cc0a0fb748099, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &2004564964
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346743, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3385760961554346745, guid: f23379ef23cb3534bb3ad06cbfdc4a05,
+        type: 3}
+      propertyPath: m_Name
+      value: AudioManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f23379ef23cb3534bb3ad06cbfdc4a05, type: 3}
+--- !u!1001 &2099263140
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1099.5751
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 368.39743
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.5895996
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899827, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193910893100899836, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: logo
+      value: 
+      objectReference: {fileID: 1220485264}
+    - target: {fileID: 1193910893100899836, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: credits
+      value: 
+      objectReference: {fileID: 607123492}
+    - target: {fileID: 1193910893100899836, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: mainMenu
+      value: 
+      objectReference: {fileID: 1417593126}
+    - target: {fileID: 1193910893100899836, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: transition
+      value: 
+      objectReference: {fileID: 57912694}
+    - target: {fileID: 1193910893100899836, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: tutorialImage
+      value: 
+      objectReference: {fileID: 57912695}
+    - target: {fileID: 1193910893100899836, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: workingCameraController
+      value: 
+      objectReference: {fileID: 1788336988}
+    - target: {fileID: 1193910893100899837, guid: 9f392e1835f784044b1660dbbdd32911,
+        type: 3}
+      propertyPath: m_Name
+      value: UIMenuControl
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9f392e1835f784044b1660dbbdd32911, type: 3}
+--- !u!1001 &944130053853809599
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436491, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 944130054936436492, guid: 9384b311f4f31e348b4dd0ee75dfba7b,
+        type: 3}
+      propertyPath: m_Name
+      value: MainLevel_Environment_Models
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9384b311f4f31e348b4dd0ee75dfba7b, type: 3}
+--- !u!1001 &2456576247520247367
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743680, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456576247095743681, guid: 9383dbc27f2ad9644a682e4cba09dbad,
+        type: 3}
+      propertyPath: m_Name
+      value: MainLevel_Lighting
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9383dbc27f2ad9644a682e4cba09dbad, type: 3}

--- a/Pine/Assets/Scenes/MechanicsTestingScene_2.unity.meta
+++ b/Pine/Assets/Scenes/MechanicsTestingScene_2.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2585c215ce1e440428a69b6cb72af4e8
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Pine/Assets/Scripts/CameraController.cs
+++ b/Pine/Assets/Scripts/CameraController.cs
@@ -18,6 +18,19 @@ public class CameraController : MonoBehaviour
     GameObject characterController = null;
 
 
+
+     /// <summary>
+     /// Returns the state machine in the character controller. 
+     /// Purpose is to access function to enter and exit the UI player state.
+     /// </summary>
+     /// <returns></returns>
+     public CharacterStateMachine GetCharacterStateMachine()
+     {
+          return characterController.GetComponent<CharacterStateMachine>();
+     }
+
+
+
      virtual public void OnGamePlay()
      {
           // Find the character controller object.

--- a/Pine/Assets/Scripts/CharacterStateMachine.cs
+++ b/Pine/Assets/Scripts/CharacterStateMachine.cs
@@ -5,9 +5,10 @@ using UnityEngine;
 public class CharacterStateMachine : FlickingMechanics
 {
 
-
+     // Character Controller player states.
      public enum PlayerState
      {
+          UI,
           Pinecone_StandingBy,
           Pinecone_Flicking,
           Pinecone_Movement,
@@ -15,16 +16,49 @@ public class CharacterStateMachine : FlickingMechanics
           Tree_StandingBy,
           Tree_Flicking
      }
-     public PlayerState playerState;
+     public PlayerState playerState = PlayerState.UI;
+
+     // Indicates whether or not the player is in the UI state.
+     bool uiPlayerState = true;
+
      AudioManager audioManager;
+
      // RNG for Random Sounds
      Random random = null; // new System.Random();
      string[] treeGroans = new string [] {"TreeGroan1", "TreeGroan2", "TreeGroan3", "TreeGroan4"};
+
+
+
+
      void Start ()
      {
           random = new Random();
           audioManager = FindObjectOfType<AudioManager>();
      }
+
+
+     /// <summary>
+     /// Meant to be called outside of the State Machine script.
+     /// Transitions player input between UI and Flicking Mechanics.
+     /// </summary>
+     /// <param name="setState"></param>
+     public void SetUiState(bool setState)
+     {
+          // Exiting the UI State
+          if (setState == false)
+          {
+               uiPlayerState = false;
+          }
+
+          // Entering the UI State
+          if (setState == true)
+          {
+               uiPlayerState = true;
+               playerState = PlayerState.UI;
+          }
+     }
+
+
 
      // The State Machine for the player.
      private void Update()
@@ -32,6 +66,18 @@ public class CharacterStateMachine : FlickingMechanics
           // Mouse Input is always running.
           MouseInput();
 
+
+          #region UI State
+
+          if (playerState == PlayerState.UI)
+          {
+               // Once declared false, then exit the UI state into the Pinecone StandingBy state.
+               if (uiPlayerState == false)
+                    playerState = PlayerState.Pinecone_StandingBy;
+          }
+
+
+          #endregion
 
           #region PineCone States --------------------
 
@@ -79,6 +125,13 @@ public class CharacterStateMachine : FlickingMechanics
           // Pinecone is locked in place, grows a tree and transitions to Tree_StandBy state.
           if (playerState == PlayerState.Pinecone_GrowTransition)
           {
+               // If no tree is attached in controller, switch to pinecone flicking.
+               if (CheckForTree() == false)
+               {
+                    playerState = PlayerState.Pinecone_StandingBy;
+                    return;
+               }
+
                GrowTreeSimple(treeObject);
                playerState = PlayerState.Tree_StandingBy;
           }

--- a/Pine/Assets/Scripts/FlickingMechanics.cs
+++ b/Pine/Assets/Scripts/FlickingMechanics.cs
@@ -2,9 +2,10 @@
 using System.Collections.Generic;
 using UnityEngine;
 
+
+[RequireComponent(typeof(FoliageGrowth))]
 public class FlickingMechanics : MonoBehaviour
 {
-
      // Camera
      GameObject playerCamera = null;
      private CameraController workingCameraController = null;
@@ -12,7 +13,6 @@ public class FlickingMechanics : MonoBehaviour
      // Mouse
      Vector2 mouseClickPosition = new Vector2(1, 1);
      Vector2 mouseCurrentPosition = new Vector2(0, 0);
-
      Vector3 flickDirection = new Vector3(0, 0, 0);
      Vector3 flickDirectionPhysics = new Vector3(0, 0, 0);
 
@@ -25,6 +25,8 @@ public class FlickingMechanics : MonoBehaviour
      [Header("Flicking Objects")]
      public GameObject objectToFlick = null;
      public GameObject treeObject = null;
+     GameObject treeHolder = null;
+     FoliageGrowth _foliageGrowth = null;
 
      [Header("Flick Attributes")]    
      [SerializeField] float objectFlickForward = 6f;  
@@ -34,7 +36,7 @@ public class FlickingMechanics : MonoBehaviour
      [SerializeField] float treeBendAmount = 6f;
 
      [SerializeField] int flicksUntilTreeGrowth = 2;
-     int currentFlickCounter = 0;
+     public int currentFlickCounter = 0;
 
      [SerializeField] float timeElapsedSinceFlick = 0.2f;
      float flickTimerCountdown = 0f;
@@ -50,8 +52,11 @@ public class FlickingMechanics : MonoBehaviour
 
 
 
+     #region --- Awake, FixedUpdate and Misc. ---
+
      private void Awake()
      {
+          // Camera
           if (playerCamera == null)
           {
                playerCamera = GameObject.FindWithTag("MainCamera");
@@ -60,6 +65,17 @@ public class FlickingMechanics : MonoBehaviour
                if (playerCamera == null)
                     Debug.Log("No camera found. Please add the 'MainCamera' tag to the camera object.");
           }
+
+          // Tree Object
+          if (treeObject == null)
+               CheckForTree(true);
+
+          // Tree Holder
+          if (treeHolder == null)
+               SearchForTreeHolder();
+
+          // Foliage Growth
+          _foliageGrowth = GetComponent<FoliageGrowth>();
 
           // Set the flick counter.
           currentFlickCounter = flicksUntilTreeGrowth;
@@ -123,11 +139,13 @@ public class FlickingMechanics : MonoBehaviour
      /// Prints out error message for not having an attached tree object for tree flicking.
      /// </summary>
      /// <returns></returns>
-     bool CheckForTree()
+     protected bool CheckForTree(bool sendMessage = false)
      {
           if (treeObject == null)
           {
-               Debug.Log("No tree object attached. Cannot perform tree flicking action.");
+               if (sendMessage == true)
+                    Debug.Log("No tree object attached. Cannot perform tree flicking action.");
+
                return false;
           }
 
@@ -135,7 +153,35 @@ public class FlickingMechanics : MonoBehaviour
      }
 
 
-     #region Mouse Input --------------------
+     /// <summary>
+     /// 
+     /// </summary>
+     void SearchForTreeHolder()
+     {
+          GameObject treeHolderRef;
+
+          // Search in scene if a Tree Holder exists.
+          // If false, create one and assign the reference.
+          if (GameObject.FindGameObjectWithTag("TreeHolder") == null)
+          {
+               GameObject newTreeHolder = new GameObject();
+               newTreeHolder.name = "TreeHolder";
+               newTreeHolder.tag = "TreeHolder";
+               treeHolderRef = newTreeHolder;
+          }
+          // If true, assign the reference.
+          else
+               treeHolderRef = GameObject.FindGameObjectWithTag("TreeHolder");
+
+          // Assign the reference to the controller's Tree Holder.
+          treeHolder = treeHolderRef;
+     }
+
+
+     #endregion
+
+
+     #region --- Mouse Input --------------------
 
      /// <summary>
      /// Checks for all mouse input.
@@ -244,7 +290,8 @@ public class FlickingMechanics : MonoBehaviour
 
      #endregion
 
-     #region Pinecone Flicking --------------------
+
+     #region --- Pinecone Flicking --------------
 
 
      /// <summary>
@@ -421,7 +468,7 @@ public class FlickingMechanics : MonoBehaviour
      #endregion
 
 
-     #region Tree Flicking --------------------
+     #region --- Tree Flicking ------------------
 
 
 
@@ -529,7 +576,7 @@ public class FlickingMechanics : MonoBehaviour
      #endregion
 
 
-     #region Gizmos --------------------
+     #region --- Gizmos -------------------------
 
 
      // Temporary UI for flicking

--- a/Pine/Assets/Scripts/FoliageGrowth.cs
+++ b/Pine/Assets/Scripts/FoliageGrowth.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FoliageGrowth : MonoBehaviour
+{
+    
+}

--- a/Pine/Assets/Scripts/FoliageGrowth.cs.meta
+++ b/Pine/Assets/Scripts/FoliageGrowth.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3381fb84f4660d47be5d8d49fd1ebde
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Pine/Assets/Scripts/UserInteractionControl.cs
+++ b/Pine/Assets/Scripts/UserInteractionControl.cs
@@ -65,6 +65,9 @@ public class UserInteractionControl : MonoBehaviour
     public void HideTutorial()
     {
         HideFromView(tutorialImage, tutorialEndPoint, movementType);
+
+        // my line - transition playerstate from ui to pinecone_standingby
+        workingCameraController.GetCharacterStateMachine().SetUiState(false);
     }
 
     public void DisplayTransition()


### PR DESCRIPTION
Game starts with UI playerState. Once tutorial is hidden, player regains control of pinecone. 

Fixed error handling for treeObject and treeHolder in FlickingMechanics. If treeObject is not added to the character state machine, then player will retain ability to flick the pinecone. If there is no treeHolder in the scene, then it's created. TreeHolder is now no longer needed in the scene.